### PR TITLE
Add base_url for image url in like/dislike

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -17,12 +17,12 @@ class PostsController < ApplicationController
 
   def like
     @post.like
-    render json: @post, status: 200
+    render json: @post, url: request.base_url, status: 200
   end
 
   def unlike
     @post.unlike
-    render json: @post, status: 200
+    render json: @post, url: request.base_url, status: 200
   end
 
   def show


### PR DESCRIPTION
Маленький фикс для следующей ситуации. Когда добавляем/отнимаем лайк, в ответе путь до картинки не содержит base_url. Получается, что он относительный. А когда запрашиваем индекс или одну запись - абсолютный. 